### PR TITLE
Issue #7: drush is an interactive command

### DIFF
--- a/scripts/drush
+++ b/scripts/drush
@@ -20,5 +20,5 @@ if [ ! -f $_DIR/helpers/common.sh ]; then
 fi
 source $_DIR/helpers/common.sh
 
-_docker_exec_noi \
+_docker_exec \
   "${DRUSH_BIN}" -r "${DRUPAL_DOCROOT}" "$@"

--- a/scripts/helpers/common.sh
+++ b/scripts/helpers/common.sh
@@ -120,6 +120,7 @@ _docker_exec() {
     $tty \
     --interactive \
     -e COLUMNS=$_COLUMN \
+    "${PROJECT_CONTAINER_NAME}" \
     "$@"
 }
 


### PR DESCRIPTION
PR for #7 

Haven't tested extensively, but this for me fixes the core issue of Drush hanging after interactive input is supplied.

Take note that this PR changes the signature of `docker_exec` helper by always passing the project container in - I can't tell if that was intentional.